### PR TITLE
update Railway template URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 To deploy your own Quirrel server to Railway, click this button:
 
-[![Deploy to Railway](https://railway.app/button.svg)](https://railway.app/new/template?code=quirrel)
+[![Deploy to Railway](https://railway.app/button.svg)](https://railway.app/new/template/quirrel)
 
 During the process, Railway will clone this repository for you. In there, you find a `Dockerfile`. To pin down your Quirrel version, update its tag:
 


### PR DESCRIPTION
Updates the template URL from `https://railway.app/new/template?code=quirrel` to `https://railway.app/new/template/quirrel`.

The new structure also allows users to use `https://dev.new/template/quirrel` 😄 